### PR TITLE
fix: resolve vercel build errors in errors.ts and vite.config.ts

### DIFF
--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,6 +1,13 @@
 export class CnbParseError extends Error {
-    constructor(message: string, public line?: string) {
+    private _line: string;
+
+    constructor(message: string, line: string = '') {
         super(message);
         this.name = "CnbParseError";
+        this._line = line;
+    }
+
+    get line(): string | undefined {
+        return this._line;
     }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite'
+import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 
 export default defineConfig({


### PR DESCRIPTION
- Change CnbParseError constructor to use default parameters instead of optional syntax
- Update vite.config.ts to use correct defineConfig from vitest/config to support test configuration types