### PR TITLE
feat: add CNB refetch logic

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,13 +5,23 @@ import { Logo } from "@/assets/Logo";
 import { RateList } from "@/components/ratesList/RateList";
 import { theme } from "@/theme";
 import { Converter } from "@/components/converter/Converter";
+import { shouldRefetchRates } from "@/util/refetchLogic";
 
 export default function App() {
   const { data, isLoading, isError, error, refetch } = useQuery({
     queryKey: ["cnb", "daily"],
     queryFn: fetchCnbDailyRates,
-    staleTime: 60_000,
-    refetchOnWindowFocus: true,
+    staleTime: 1000 * 60 * 60 * 24, // Consider data fresh for 24 hours
+    refetchOnWindowFocus: (query) => {
+      // Only refetch on window focus if it makes sense based on CNB schedule
+      // Use the actual CNB data date instead of query execution time
+      return shouldRefetchRates(query.state.data?.date);
+    },
+    refetchInterval: () => {
+      // Disable automatic background refetching - prioritize window focus handling
+      // to ensure users get the most current data when they return to the app
+      return false;
+    },
   });
 
   return (

--- a/src/util/refetchLogic.ts
+++ b/src/util/refetchLogic.ts
@@ -1,0 +1,82 @@
+/**
+ * Smart refetch logic for CNB daily rates
+ * CNB updates rates once per business day at 14:30 Czech time
+ */
+
+export function shouldRefetchRates(cnbDataDate?: string): boolean {
+    console.group('[CNB Refetch] Evaluating refetch decision');
+    console.log('[CNB Refetch] CNB data date:', cnbDataDate || 'none');
+
+    if (!cnbDataDate) {
+        console.log('[CNB Refetch] Decision: REFETCH - No existing data');
+        console.groupEnd();
+        return true;
+    }
+
+    const czechNow = new Date(new Date().toLocaleString("en-US", { timeZone: "Europe/Prague" }));
+    console.log('[CNB Refetch] Current Czech time:', czechNow.toLocaleString('cs-CZ'));
+
+    if (isWeekend(czechNow)) {
+        console.log('[CNB Refetch] Decision: NO REFETCH - Weekend (CNB closed)');
+        console.groupEnd();
+        return false;
+    }
+
+    // Parse CNB date (format: "26 Sep 2025") and set to 14:30 Czech time
+    const cnbDate = parseCnbDate(cnbDataDate);
+    if (!cnbDate) {
+        console.log('[CNB Refetch] Decision: REFETCH - Invalid date format, refetching for safety');
+        console.groupEnd();
+        return true;
+    }
+
+    const cnbPublishTime = new Date(cnbDate);
+    cnbPublishTime.setHours(14, 30, 0, 0);
+
+    const todayPublishTime = new Date(czechNow);
+    todayPublishTime.setHours(14, 30, 0, 0);
+
+    console.log('[CNB Refetch] Data published on:', cnbPublishTime.toLocaleDateString('cs-CZ'));
+    console.log('[CNB Refetch] Today publish time:', todayPublishTime.toLocaleString('cs-CZ'));
+
+    // If current Czech time is before today's publish time, don't refetch yet
+    if (czechNow < todayPublishTime) {
+        console.log('[CNB Refetch] Decision: NO REFETCH - Before 14:30 today');
+        console.groupEnd();
+        return false;
+    }
+
+    // If we have today's data (published after 14:30), don't refetch
+    if (isSameDay(czechNow, cnbPublishTime)) {
+        console.log('[CNB Refetch] Decision: NO REFETCH - Already have current data');
+        console.groupEnd();
+        return false;
+    }
+
+    console.log('[CNB Refetch] Decision: REFETCH - Data is outdated and new data available');
+    console.groupEnd();
+    return true;
+}
+
+function parseCnbDate(dateString: string): Date | null {
+    try {
+        // CNB format: "26 Sep 2025"
+        const date = new Date(dateString);
+        return isNaN(date.getTime()) ? null : date;
+    } catch {
+        return null;
+    }
+}
+
+function isSameDay(date1: Date, date2: Date): boolean {
+    return (
+        date1.getFullYear() === date2.getFullYear() &&
+        date1.getMonth() === date2.getMonth() &&
+        date1.getDate() === date2.getDate()
+    );
+}
+
+function isWeekend(date: Date): boolean {
+    const day = date.getDay();
+    return day === 0 || day === 6; // Sunday = 0, Saturday = 6
+}

--- a/tests/util/refetchLogic.test.ts
+++ b/tests/util/refetchLogic.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { shouldRefetchRates } from "@/util/refetchLogic";
+
+// Mock the current date for consistent testing
+const mockDate = (dateString: string) => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(dateString));
+};
+
+const restoreDate = () => {
+    vi.useRealTimers();
+};
+
+describe("shouldRefetchRates", () => {
+    beforeEach(() => {
+        // Mock console methods to avoid noise in test output
+        vi.spyOn(console, 'group').mockImplementation(() => { });
+        vi.spyOn(console, 'groupEnd').mockImplementation(() => { });
+        vi.spyOn(console, 'log').mockImplementation(() => { });
+    });
+
+    afterEach(() => {
+        restoreDate();
+        vi.restoreAllMocks();
+    });
+
+    describe("no CNB data date is provided", () => {
+        it("should refetch when cnbDataDate is undefined", () => {
+            mockDate("2025-10-01T10:00:00.000Z"); // Wednesday 10:00 UTC
+            expect(shouldRefetchRates(undefined)).toBe(true);
+        });
+
+        it("should refetch when cnbDataDate is empty string", () => {
+            mockDate("2025-10-01T10:00:00.000Z");
+            expect(shouldRefetchRates("")).toBe(true);
+        });
+    });
+
+    describe("weekend behavior", () => {
+        it("does not refetch on Saturday", () => {
+            mockDate("2025-01-18T15:00:00.000Z"); // Saturday 15:00 UTC (16:00 Prague)
+            expect(shouldRefetchRates("17 Jan 2025")).toBe(false);
+        });
+
+        it("does not refetch on Sunday", () => {
+            mockDate("2025-01-19T15:00:00.000Z"); // Sunday 15:00 UTC (16:00 Prague)
+            expect(shouldRefetchRates("17 Jan 2025")).toBe(false);
+        });
+    });
+
+    describe("invalid date format handling", () => {
+        it("should refetch when date format is invalid", () => {
+            expect(shouldRefetchRates("invalid-date")).toBe(true);
+        });
+
+        it("should refetch when date is malformed", () => {
+            mockDate("2025-01-15T15:00:00.000Z");
+            expect(shouldRefetchRates("32 Feb 2025")).toBe(true);
+        });
+    });
+
+    describe("before 14:30 Czech time behavior", () => {
+        it("should not refetch at 10:00 Prague time on weekday", () => {
+            mockDate("2025-01-15T09:00:00.000Z"); // Wednesday 09:00 UTC = 10:00 Prague
+            expect(shouldRefetchRates("14 Jan 2025")).toBe(false);
+        });
+
+        it("should not refetch at 14:29 Prague time on weekday", () => {
+            mockDate("2025-01-15T13:29:00.000Z"); // Wednesday 13:29 UTC = 14:29 Prague
+            expect(shouldRefetchRates("14 Jan 2025")).toBe(false);
+        });
+    });
+
+    describe("after 14:30 Czech time behavior", () => {
+        it("should not refetch when we have current day's data", () => {
+            mockDate("2025-01-15T14:00:00.000Z"); // Wednesday 14:00 UTC = 15:00 Prague
+            expect(shouldRefetchRates("15 Jan 2025")).toBe(false);
+        });
+
+        it("should refetch when data is from previous day and it's after 14:30", () => {
+            mockDate("2025-01-15T14:00:00.000Z"); // Wednesday 14:00 UTC = 15:00 Prague
+            expect(shouldRefetchRates("14 Jan 2025")).toBe(true);
+        });
+
+        it("should refetch when data is from several days ago", () => {
+            mockDate("2025-01-15T14:00:00.000Z"); // Wednesday 14:00 UTC = 15:00 Prague
+            expect(shouldRefetchRates("10 Jan 2025")).toBe(true);
+        });
+    });
+
+    describe("edge cases around 14:30", () => {
+        it("should refetch exactly at 14:30 Prague time with old data", () => {
+            mockDate("2025-01-15T13:30:00.000Z"); // Wednesday 13:30 UTC = 14:30 Prague
+            expect(shouldRefetchRates("14 Jan 2025")).toBe(true);
+        });
+
+        it("should not refetch exactly at 14:30 Prague time with current data", () => {
+            mockDate("2025-01-15T13:30:00.000Z"); // Wednesday 13:30 UTC = 14:30 Prague
+            expect(shouldRefetchRates("15 Jan 2025")).toBe(false);
+        });
+    });
+
+    describe("different date formats", () => {
+        it("should handle CNB date format correctly", () => {
+            mockDate("2025-01-15T14:00:00.000Z"); // Wednesday 14:00 UTC = 15:00 Prague
+            expect(shouldRefetchRates("15 Jan 2025")).toBe(false);
+            expect(shouldRefetchRates("14 Jan 2025")).toBe(true);
+        });
+
+        it("should handle full month names", () => {
+            mockDate("2025-01-15T14:00:00.000Z");
+            expect(shouldRefetchRates("15 January 2025")).toBe(false);
+            expect(shouldRefetchRates("14 January 2025")).toBe(true);
+        });
+    });
+});


### PR DESCRIPTION
## feat: add CNB refetch logic

### Summary
Replaces constant polling with refetch logic that follows CNB's actual publishing schedule.

### Implementation
- `shouldRefetchRates()`: Checks if refetch needed based on CNB data date vs current time
- Updated query config to prioritize window focus over background intervals